### PR TITLE
Allow s3 key to be overriden with s3_key_stem

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Full list of options in `config.json`:
 | aws_profile                         | String  | No         | AWS profile name for profile based authentication. If not provided, `AWS_PROFILE` environment variable will be used. |
 | s3_bucket                           | String  | Yes        | S3 Bucket name                                                |
 | s3_key_prefix                       | String  |            | A static prefix before the generated S3 key names. Using prefixes you can upload files into specific directories in the S3 bucket. Default(None)
+| s3_key_stem | String | No | (Default: current timestamp) Custom name for the stem of the s3_key. Follows the prefix & stream name, precedes the file format. 
 | s3_staging_dir                       | String  | Yes         | S3 location to stage files. Example: s3://YOUR_S3_BUCKET/path/to/
 | delimiter                           | String  |            | (Default: ',') A one-character string used to separate fields. |
 | quotechar                           | String  |            | (Default: '"') A one-character string used to quote fields containing special characters, such as the delimiter or quotechar, or which contain new-line characters. |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Full list of options in `config.json`:
 | encryption_type                     | String  | No         | (Default: 'none') The type of encryption to use. Current supported options are: 'none' and 'KMS'. |
 | encryption_key                      | String  | No         | A reference to the encryption key to use for data encryption. For KMS encryption, this should be the name of the KMS encryption key ID (e.g. '1234abcd-1234-1234-1234-1234abcd1234'). This field is ignored if 'encryption_type' is none or blank. |
 | compression                         | String  | No         | The type of compression to apply before uploading. Supported options are `none` (default) and `gzip`. For gzipped files, the file extension will automatically be changed to `.csv.gz` for all files. |
-| naming_convention                   | String  | No         | (Default: None) Custom naming convention of the s3 key. Replaces tokens `date`, `stream`, and `timestamp` with the appropriate values. <br><br>Supports "folders" in s3 keys e.g. `folder/folder2/{stream}/export_date={date}/{timestamp}.csv`. <br><br>Honors the `s3_key_prefix`,  if set, by prepending the "filename". E.g. naming_convention = `folder1/my_file.csv` and s3_key_prefix = `prefix_` results in `folder1/prefix_my_file.csv` |
 | temp_dir                            | String  |            | (Default: platform-dependent) Directory of temporary CSV files with RECORD messages. |
 
 ### To run tests:

--- a/target_athena/sinks.py
+++ b/target_athena/sinks.py
@@ -70,6 +70,7 @@ class AthenaSink(BatchSink):
 
         filenames = []
         now = datetime.now().strftime("%Y%m%dT%H%M%S")
+        key_stem = self.config.get("s3_key_stem", None) or now
 
         # Serialize records to local files
         for record in records_to_drain:
@@ -83,7 +84,7 @@ class AthenaSink(BatchSink):
                 self.stream_name,
                 object_format,
                 prefix=s3_prefix,
-                timestamp=now,
+                key_stem=key_stem,
                 # naming_convention=self.config.get("naming_convention"),
             )
             if not (filename, target_key) in filenames:

--- a/target_athena/sinks.py
+++ b/target_athena/sinks.py
@@ -1,5 +1,3 @@
-"""Sample Parquet target stream class, which handles writing streams."""
-
 import gzip
 import os
 import shutil
@@ -85,7 +83,6 @@ class AthenaSink(BatchSink):
                 object_format,
                 prefix=s3_prefix,
                 key_stem=key_stem,
-                # naming_convention=self.config.get("naming_convention"),
             )
             if not (filename, target_key) in filenames:
                 filenames.append((filename, target_key))

--- a/target_athena/utils.py
+++ b/target_athena/utils.py
@@ -53,12 +53,7 @@ def flatten_record(d, parent_key=[], sep="__"):
     return dict(items)
 
 
-def get_target_key(stream_name, object_format, prefix="", timestamp=None, naming_convention=None):
+def get_target_key(stream_name, object_format, key_stem, prefix="", naming_convention=None):
     """Creates and returns an S3 key for the message"""
 
-    if not timestamp:
-        timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
-
-    key = f"{prefix}{stream_name}/{timestamp}.{object_format}"
-
-    return key 
+    return f"{prefix}{stream_name}/{key_stem}.{object_format}"

--- a/target_athena/utils.py
+++ b/target_athena/utils.py
@@ -53,7 +53,7 @@ def flatten_record(d, parent_key=[], sep="__"):
     return dict(items)
 
 
-def get_target_key(stream_name, object_format, key_stem, prefix="", naming_convention=None):
+def get_target_key(stream_name, object_format, key_stem, prefix=""):
     """Creates and returns an S3 key for the message"""
 
     return f"{prefix}{stream_name}/{key_stem}.{object_format}"


### PR DESCRIPTION
The key stem is the last part of the object name excluding the file
format: e.g. "stem" in s3://some-bucket/stem.json.gz
Prior implementation forced the stem of the key to be the current
timestamp. If s3_key_stem is not provided in configuration, the current
timestamp will be used by default as before. Otherwise, the value for
s3_key_stem will be used.